### PR TITLE
feat: add webp format

### DIFF
--- a/declaration.d.ts
+++ b/declaration.d.ts
@@ -1,0 +1,8 @@
+declare module '*.webp' {
+  const value: ImgSrc;
+  export = value;
+}
+declare module "*.json" {
+  const value: any;
+  export default value;
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,7 +1,8 @@
 const path = require('path')
 const HTMLWebpackPlugin = require('html-webpack-plugin')
-const {CleanWebpackPlugin} = require('clean-webpack-plugin')
+const { CleanWebpackPlugin } = require('clean-webpack-plugin')
 const EslingPlugin = require('eslint-webpack-plugin');
+const CopyWebpackPlugin = require('copy-webpack-plugin')
 
 module.exports = {
   mode: 'development',
@@ -11,6 +12,12 @@ module.exports = {
     path: path.resolve(__dirname, './dist')
   },
   plugins: [
+    new CopyWebpackPlugin({
+      patterns: [{
+        from: path.resolve(__dirname, './src/assets'),
+        to: path.resolve(__dirname, './dist/data'),
+      },]
+    }),
     new HTMLWebpackPlugin({
       template: path.resolve(__dirname, './src/index.html'),
       filename: 'index.html'
@@ -38,10 +45,10 @@ module.exports = {
         use: ['style-loader', 'css-loader', 'sass-loader'],
       },
       {
-        test: /\.(png|svg|jpg|jpeg|gif)$/i,
+        test: /\.(png|svg|jpg|jpeg|gif|webp)$/i,
         type: 'asset/resource'
       },
-      { 
+      {
         test: /\\.(png|jp(e*)g|svg|gif)$/,
         use: ['file-loader'],
       }


### PR DESCRIPTION
c copy webpack plugin просто переносим директорию с данными и задаём элементам src(только нужно добавить точку к пути который указан в products.json)

const img = document.createElement('img') as HTMLImageElement;
img.src = './data/products/1/1.webp';

так же можно импортировать картинки(но это скорее всего не понадобится):
import picture from './assets/products/1/2.webp'
img.src = picture

json файл тоже можно импортнуть в ts